### PR TITLE
refactor: 즐겨찾기 Combine으로 리팩토링

### DIFF
--- a/Projects/App/Sources/Views/BookMark/BookMarkView.swift
+++ b/Projects/App/Sources/Views/BookMark/BookMarkView.swift
@@ -31,9 +31,7 @@ struct BookMarkView: View {
                             }
                             .padding()
                             .navigationDestination(isPresented: $bookMarkVM.isDetailPresented) {
-                                MainDetailView(vm: bookMarkDetailVM, mainVM: bookMarkVM) {
-                                    bookMarkVM.fetchBookMark()
-                                }
+                                MainDetailView(vm: bookMarkDetailVM, mainVM: bookMarkVM)
                             }
                         }
                     }

--- a/Projects/App/Sources/Views/MainDetail/Architectures/MainDetailVM.swift
+++ b/Projects/App/Sources/Views/MainDetail/Architectures/MainDetailVM.swift
@@ -27,12 +27,12 @@ class MainDetailVM: ObservableObject {
     @Published var selectedStationBorderColor: String = ""
     /// 서연추가) 유저가 역팝업뷰에서 역 선택하였을 때 배경 분기처리를 위한 프로퍼티
     @Published var userSelectedStation: String?
-  
+    
     /// 네트워크 끊겼을 경우 메세지
     @Published var networkDiedToastMessage: Toast?
     /// 북마크 추가/해제시 메세지
     @Published var bookMarkInfoToastMessage: Toast?
-
+    
     /// 해당역 북마크 추가/해제 표시
     @Published var isBookMarked: Bool = false
     /// 역이 두개이상일경우 선택팝업 표시
@@ -72,7 +72,6 @@ class MainDetailVM: ObservableObject {
     func settingSubwayInfo(hosun: SubwayLineColor, selectStation: MyStation) {
         self.hosunInfo = hosun
         self.fetchInfo(selectStation)
-
         fetchBookMark()
     }
     
@@ -117,17 +116,17 @@ class MainDetailVM: ObservableObject {
         let line = lineInfos.filter { $0.subwayId == item.subwayId }.first ?? .emptyData
         
         self.settingSubwayInfo(hosun: line, selectStation: mystation)
-
+        
     }
     
     /// 타이머 시작
     func timerStart() {
         self.timerCancel = Timer.publish(every: gapiFetchTimeSecond, on: .main, in: .default)
-                    .autoconnect()
-                    .sink { _ in
-                        self.settingSubwayInfoWithDebounce(selectStationInfo: self.selectStationInfo,
-                                  lineInfo: self.hosunInfo)
-                    }
+            .autoconnect()
+            .sink { _ in
+                self.settingSubwayInfoWithDebounce(selectStationInfo: self.selectStationInfo,
+                                                   lineInfo: self.hosunInfo)
+            }
         
     }
     
@@ -205,7 +204,7 @@ extension MainDetailVM {
         let stationData = stationName
         
         stationInfos = stationInfos.filter { $0.subwayId == hosunInfo.subwayId }
- 
+        
         if !stationInfos.contains(where: { $0.statnNm == stationName }) {
             // 선택한 라인에서 역코드가 제일 작은걸 가져온다.
             if let firstData = stationInfos.first {
@@ -255,10 +254,10 @@ extension MainDetailVM {
     private func getRealTimeInfo(selectStationInfo: MyStation) {
         upRealTimeInfos.removeAll() // 초기화
         downRealTimeInfos.removeAll() // 초기화
-
+        
         // 해당 호선번호로 filter, 역명으로 openAPI 통신.
         useCase.recievePublisher(subwayLine: "\(hosunInfo.subwayId)", stationInfo: selectStationInfo)
-            // sink로 구독시 publisher의 타입의 에러 형태가 Never가 아닐경우에는 receiveCompelete도 무조건 작성해야함.
+        // sink로 구독시 publisher의 타입의 에러 형태가 Never가 아닐경우에는 receiveCompelete도 무조건 작성해야함.
             .sink { result in
                 switch result {
                 case .finished:
@@ -272,7 +271,7 @@ extension MainDetailVM {
                     }
                 }
             } receiveValue: { data in
- 
+                
                 let newData = data.sorted { $0.stCnt < $1.stCnt }
                 Log.trace("데이터 갯수: \(newData.count)")
                 

--- a/Projects/App/Sources/Views/MainDetail/Views/MainDetailView.swift
+++ b/Projects/App/Sources/Views/MainDetail/Views/MainDetailView.swift
@@ -6,9 +6,9 @@ struct MainDetailView: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var vm: MainDetailVM
     @ObservedObject var mainVM: MainListVM
-    var disappearHandler: () -> Void = {}
     @State private var offset: CGFloat = .zero
     @State private var rotationAngle: Angle = .zero
+    
     private var swipeToNext: some Gesture {
         DragGesture()
             .onChanged { value in
@@ -68,7 +68,6 @@ struct MainDetailView: View {
         }
         .onDisappear { 
             vm.timerStop()
-            disappearHandler()
         }
         .onTapGesture {
             self.endTextEditing()


### PR DESCRIPTION
# #76 

<img width="730" alt="스크린샷 2024-03-07 오후 4 50 48" src="https://github.com/MetroMates/metroCity/assets/127810279/bc498ee3-6283-4520-8378-98529625718d">

### 1. NotificationCenter 사용
- NotificationCenter : 특정 이벤트가 발생했을 때, 해당 이벤트에 관심이 있는 객체들에게 메시지를 전달하는 패턴을 구현하는 클래스
- .default : NotificationCenter의 싱글톤 인스턴스

### 2. NSManagedObjectContext.didSaveObjectsNotification 결합
- .publisher(for:) : 특정 이벤트를 구독하는 데 사용되는 메서드
- NSManagedObjectContext.didSaveObjectsNotification : CoreData의 NSManagedObjectContext에서 변경이 저장될 때마다 발생

### 3. Combine 활용
- .sink : Publisher로부터 오는 값을 처리 -> 값이 변경되면 fetchBookMark() 메서드 호출